### PR TITLE
Adjust Notification Adapters: so that the regular notification of a pood...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Adjust Notification Adapters: so that the regular notification of a poodle works still fine.
+  [phgross]
+
 - Fix: Do no override Owner role.
   [mathias.leimgruber]
 

--- a/ftw/poodle/adapters.py
+++ b/ftw/poodle/adapters.py
@@ -14,7 +14,7 @@ def get_full_name(context):
     return member.id
 
 
-class PoodleSubjectCreator(object):
+class PoodleFilledOutSubjectCreator(object):
     def __init__(self, context):
         self.context = aq_inner(context)
         self.request = self.context.REQUEST
@@ -31,7 +31,7 @@ class PoodleSubjectCreator(object):
         return subject
 
 
-class PoodleEmailRepresentation(BaseEmailRepresentation):
+class PoodleFilledOutEmailRepresentation(BaseEmailRepresentation):
 
     template = ViewPageTemplateFile('poodle_notification.pt')
 

--- a/ftw/poodle/browser/submit_data.py
+++ b/ftw/poodle/browser/submit_data.py
@@ -2,8 +2,10 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from ftw.notification.base.interfaces import INotifier
 from ftw.poodle import poodleMessageFactory as _
+from ftw.poodle.interfaces import IPoodleFilledOutMarker
 from ftw.poodle.interfaces import IPoodleVotes
 from zope.component import queryMultiAdapter, queryUtility
+from zope.interface import directlyProvides, noLongerProvides
 
 
 class JQSubmitData(BrowserView):
@@ -66,6 +68,8 @@ class JQSubmitData(BrowserView):
 
         # notify with ftw.notifaction.email
         notifier = queryUtility(INotifier, name='email-notifier')
+        directlyProvides(self.context, IPoodleFilledOutMarker)
         notifier.send_notification(
             to_list=[self.context.Creator()],
             object_=self.context)
+        noLongerProvides(self.context, IPoodleFilledOutMarker)

--- a/ftw/poodle/configure.zcml
+++ b/ftw/poodle/configure.zcml
@@ -42,14 +42,14 @@
 
     <adapter
         provides="ftw.notification.email.interfaces.ISubjectCreator"
-        factory=".adapters.PoodleSubjectCreator"
-        for=".interfaces.IPoodle"
+        factory=".adapters.PoodleFilledOutSubjectCreator"
+        for=".interfaces.IPoodleFilledOutMarker"
         />
 
     <adapter
         provides="ftw.notification.email.interfaces.IEMailRepresentation"
-        factory=".adapters.PoodleEmailRepresentation"
-        for=".interfaces.IPoodle"
+        factory=".adapters.PoodleFilledOutEmailRepresentation"
+        for=".interfaces.IPoodleFilledOutMarker"
         />
 
       <!-- register user vocabulary-->

--- a/ftw/poodle/interfaces.py
+++ b/ftw/poodle/interfaces.py
@@ -18,3 +18,8 @@ class IPoodletableBottom(IViewletManager):
     packages.
 
     """
+
+
+class IPoodleFilledOutMarker(IPoodle):
+    """Marker interfaces for Filledout Poodle
+    """

--- a/ftw/poodle/tests.zcml
+++ b/ftw/poodle/tests.zcml
@@ -14,21 +14,26 @@
 
     <adapter
         provides="ftw.notification.email.interfaces.ISubjectCreator"
-        factory=".adapters.PoodleSubjectCreator"
-        for=".interfaces.IPoodle"
+        factory=".adapters.PoodleFilledOutSubjectCreator"
+        for=".interfaces.IPoodleFilledOutMarker"
         />
 
     <adapter
         provides="ftw.notification.email.interfaces.IEMailRepresentation"
-        factory=".adapters.PoodleEmailRepresentation"
-        for=".interfaces.IPoodle"
+        factory=".adapters.PoodleFilledOutEmailRepresentation"
+        for=".interfaces.IPoodleFilledOutMarker"
         />
 
-    <!-- <browser:page -->
-    <!--     for=".interfaces.IPoodle" -->
-    <!--     name="jq_submit_data" -->
-    <!--     class=".browser.submit_data.JQSubmitData" -->
-    <!--     permission="zope2.View" -->
-    <!--     /> -->
+  <adapter
+      factory="ftw.notification.email.templates.base.BaseEmailRepresentation"
+      for="Products.CMFCore.interfaces._content.IContentish"
+      provides="ftw.notification.email.interfaces.IEMailRepresentation"
+      />
+
+  <adapter
+      factory="ftw.notification.email.adapters.BaseSubjectCreator"
+      for="Products.Archetypes.interfaces.base.IBaseObject"
+      provides="ftw.notification.email.interfaces.ISubjectCreator"
+      />
 
 </configure>

--- a/ftw/poodle/tests/test_notification.py
+++ b/ftw/poodle/tests/test_notification.py
@@ -1,6 +1,10 @@
+from Products.Archetypes.interfaces.base import IBaseObject
+from Products.CMFCore.interfaces._content import IContentish
+from ftw.notification.email.adapters import BaseSubjectCreator
 from ftw.notification.email.interfaces import IEMailRepresentation
 from ftw.notification.email.interfaces import ISubjectCreator
-from ftw.poodle.interfaces import IPoodle
+from ftw.notification.email.templates.base import BaseEmailRepresentation
+from ftw.poodle.interfaces import IPoodleFilledOutMarker, IPoodle
 from ftw.poodle.testing import POODLE_VOTES_ZCML_LAYER
 from ftw.testing import MockTestCase
 from zope.interface import Interface
@@ -11,8 +15,8 @@ class TestNotificationAdapters(MockTestCase):
 
     layer = POODLE_VOTES_ZCML_LAYER
 
-    def test_subject_creator(self):
-        poodle = self.providing_stub([IPoodle])
+    def test_filled_out_subject_creator(self):
+        poodle = self.providing_stub([IPoodleFilledOutMarker])
         request = self.stub_request()
         self.expect(poodle.REQUEST).result(request)
 
@@ -28,11 +32,10 @@ class TestNotificationAdapters(MockTestCase):
         self.assertEquals(
             subject, u'The User Hugo Boss has filled out your poodle')
 
-    def test_email_representation(self):
+    def test_filled_out_email_representation(self):
         # poodle and request stuff
-        poodle = self.providing_stub([IPoodle])
+        poodle = self.providing_stub([IPoodleFilledOutMarker])
         request = self.stub_request()
-        response = self.stub_response()
         self.expect(poodle.REQUEST).result(request)
         self.expect(poodle.absolute_url).result(
             'http://localhost:8080/platform/poodle-1')
@@ -64,3 +67,21 @@ class TestNotificationAdapters(MockTestCase):
 
         self.assertEquals(
             email.template(),'\n\n The user hugo.boss\n has entered his data into the meeting poll at\n http://localhost:8080/platform/poodle-1\n on the website My poodle portal\n at http://localhost:8080/platform\n\n\n')
+
+    def test_regular_notications(self):
+        poodle = self.providing_stub(
+            [IPoodle, IContentish, IBaseObject])
+
+        request = self.stub_request()
+        self.expect(poodle.REQUEST).result(request)
+
+        self.replay()
+
+
+        self.assertEquals(
+            type(IEMailRepresentation(poodle)),
+            BaseEmailRepresentation)
+
+        self.assertEquals(
+            type(ISubjectCreator(poodle)),
+            BaseSubjectCreator)

--- a/ftw/poodle/tests/test_submit.py
+++ b/ftw/poodle/tests/test_submit.py
@@ -107,11 +107,11 @@ class TestJQSubmit(MockTestCase):
         view._create_journal_entry(user)
 
     def test_notification(self):
-        poodle = self.stub()
         request = self.stub()
-        self.expect(poodle.REQUEST).result(request)
-        self.expect(poodle.Title()).result('Test Poll')
-        self.expect(poodle.Creator()).result('hugo.boss')
+        poodle = self.create_dummy(
+            REQUEST=request,
+            Title='Test Poll',
+            Creator=lambda: 'hugo.boss')
 
         notifier = self.stub()
         self.mock_utility(
@@ -123,4 +123,5 @@ class TestJQSubmit(MockTestCase):
 
         view = JQSubmitData(poodle, request)
         view.poodle = poodle
+
         view._send_notification()


### PR DESCRIPTION
Adjust Notification Adapters:
The adpaters are now registred for the specific IPoodleFilledOutMarker Interface so that the regular notification of a poodle (standard ftw.notification.base functionality) works correctly and use the standard EmailRepresentation and SubjectCreators.
