### PR TITLE
fix typo: multivalued -> multiValued

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix typo in the 'users' field of PoodleSchema: multivalued ->
+  multiValued [cillianderoiste]
 
 
 1.4.1 (2014-06-11)

--- a/ftw/poodle/content/poodle.py
+++ b/ftw/poodle/content/poodle.py
@@ -20,7 +20,7 @@ PoodleSchema = schemata.ATContentTypeSchema.copy() + atapi.Schema((
                 label=_(u'ftwpoodle_label_users', default=u'Users'),
                 actb_expand_onfocus=1),
             required=1,
-            multivalued=1),
+            multiValued=1),
 
         DataGridField(
             name='dates',


### PR DESCRIPTION
I noticed this when overriding the InAndOutWidget with Products.AutocompleteWidget.