### PR TITLE
Implement stealth voting feature

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add checkbox to enable stealth voting.
+  [raphael-s]
 
 
 1.5.0 (2015-05-06)

--- a/ftw/poodle/browser/templates/poodletable.pt
+++ b/ftw/poodle/browser/templates/poodletable.pt
@@ -9,16 +9,17 @@
                      users view/get_sorted_users;
                      dates context/getDates;
                      member here/@@plone_portal_state/member">
-      <tr>
+      <tr class="poodle-dates">
           <th></th>
           <th tal:repeat="date dates">
               <span tal:replace="date/date" /><br />
               <span tal:replace="date/duration"/>
           </th>
       </tr>
-      <tr tal:repeat="user users">
+      <tr tal:repeat="user users" class="poodle-user">
           <tal:block define="currentUser python:view.isCurrentUser(user)">
-              <td tal:attributes="style python:currentUser and 'opacity:1' or 'opacity:0.5'" tal:content="python:view.getUserFullname(user)"/>
+              <td tal:attributes="style python:currentUser and 'opacity:1' or 'opacity:0.5'" tal:content="python:view.getUserFullname(user)"
+              class="user"/>
               <tal:block repeat="choice python:context.getDatesHash()">
                   <td tal:define="index repeat/choice/index;
                                   date_id python:poodledata['ids'][index];
@@ -50,7 +51,7 @@
           </tal:block>
       </tr>
       <tal:if condition="python:view.show_results()">
-        <tr>
+        <tr class="poodle-results">
               <td i18n:translate="ftwpoodle_results">
                   Results
               </td>

--- a/ftw/poodle/browser/templates/poodletable.pt
+++ b/ftw/poodle/browser/templates/poodletable.pt
@@ -49,14 +49,16 @@
               </tal:block>
           </tal:block>
       </tr>
-      <tr>
-            <td i18n:translate="ftwpoodle_results">
-                Results
-            </td>
-            <td tal:replace="structure python:view.poodleResults(data=poodledata)">
-                poodle results
-            </td>
-      </tr>
+      <tal:if condition="python:view.show_results()">
+        <tr>
+              <td i18n:translate="ftwpoodle_results">
+                  Results
+              </td>
+              <td tal:replace="structure python:view.poodleResults(data=poodledata)">
+                  poodle results
+              </td>
+        </tr>
+      </tal:if>
   </table>
   <div class="inputs" tal:condition="view/show_inputs">
       <input type="text" name="uid" tal:attributes="value string:${context/UID}" style="display:none" />

--- a/ftw/poodle/content/poodle.py
+++ b/ftw/poodle/content/poodle.py
@@ -39,6 +39,15 @@ PoodleSchema = schemata.ATContentTypeSchema.copy() + atapi.Schema((
                 label=_(u'ftwpoodle_label_dates', default=u'Dates')),
             columns=("date", "duration")),
 
+        atapi.BooleanField(
+            name="stealth_voting",
+            widget=atapi.BooleanWidget(
+                label=_(u'stealth_voting', default=u'Enable stealth voting'),
+            ),
+            default=True,
+            required=False
+        ),
+
         ))
 
 

--- a/ftw/poodle/locales/de/LC_MESSAGES/ftw.poodle.po
+++ b/ftw/poodle/locales/de/LC_MESSAGES/ftw.poodle.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-06 07:54+0000\n"
+"POT-Creation-Date: 2016-10-21 07:50+0000\n"
 "PO-Revision-Date: 2012-08-10 14:30+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,6 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/poodle/configure.zcml:30
 msgid "A product to make polls to find out when to have a meeting"
 msgstr "Ein Produkt für Sitzungsumfragen."
 
@@ -18,17 +19,25 @@ msgstr "Ein Produkt für Sitzungsumfragen."
 msgid "Meeting poll"
 msgstr "Sitzungsumfrage"
 
+#: ./ftw/poodle/upgrades/configure.zcml:14
+msgid "Remove poodle.js from jsregistry"
+msgstr ""
+
 #: ./ftw/poodle/browser/submit_data.py:30
 msgid "You taked part to the poll"
 msgstr "Sie haben an der Umfrage teilgenommen."
 
+#: ./ftw/poodle/configure.zcml:30
+msgid "ftw.poodle"
+msgstr ""
+
 #. Default: "Date"
-#: ./ftw/poodle/content/poodle.py:31
+#: ./ftw/poodle/content/poodle.py:30
 msgid "ftwpoodle_desc_date"
 msgstr "Format"
 
 #. Default: "Time / Duration"
-#: ./ftw/poodle/content/poodle.py:36
+#: ./ftw/poodle/content/poodle.py:35
 msgid "ftwpoodle_desc_duration"
 msgstr "Zeit / Dauer (HH:MM-HH:MM)"
 
@@ -38,12 +47,12 @@ msgid "ftwpoodle_edit_votes"
 msgstr "Umfrage bearbeiten"
 
 #. Default: "Provide a date in a format like MM-DD-AAAA"
-#: ./ftw/poodle/content/poodle.py:33
+#: ./ftw/poodle/content/poodle.py:32
 msgid "ftwpoodle_help_date"
 msgstr "Datumsformat: TT.MM.YYYY (z.B. 22.10.2015)"
 
 #. Default: "Dates"
-#: ./ftw/poodle/content/poodle.py:40
+#: ./ftw/poodle/content/poodle.py:39
 msgid "ftwpoodle_label_dates"
 msgstr "Datum"
 
@@ -58,7 +67,7 @@ msgid "ftwpoodle_mail_subject"
 msgstr "Der Benutzer ${username} hat ihre Sitzungsumfrage ausgefüllt"
 
 #. Default: "Results"
-#: ./ftw/poodle/browser/templates/poodletable.pt:50
+#: ./ftw/poodle/browser/templates/poodletable.pt:54
 msgid "ftwpoodle_results"
 msgstr "Resultat"
 
@@ -77,6 +86,11 @@ msgstr "Noch keine Terminvorschläge definiert"
 msgid "poodle_mailtemplate_body"
 msgstr "Der Benutzer ${user_name} hat an der Umfrage ${document_url} auf ${portal_title} teilgenommen"
 
+#. Default: "Enable stealth voting"
+#: ./ftw/poodle/content/poodle.py:45
+msgid "stealth_voting"
+msgstr "Verdeckte Abstimmung"
+
 #. Default: "Survey is deactivated"
 #: ./ftw/poodle/browser/poodle.py:23
 msgid "survey_deactivated"
@@ -86,3 +100,4 @@ msgstr "Diese Umfrage ist deaktiviert."
 #: ./ftw/poodle/browser/templates/voted.pt:2
 msgid "text_voted"
 msgstr "Ihre Eingabe wurde erfolgreich gespeichert. Klicken Sie auf \"Umfrage bearbeiten\", um Ihre Eingabe zu ändern."
+

--- a/ftw/poodle/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/poodle/locales/de/LC_MESSAGES/plone.po
@@ -30,3 +30,4 @@ msgstr "Offen"
 #: ../profiles/default/workflows/poodle_workflow/definition.xml
 msgid "Open poodle"
 msgstr "Wieder eröffnen"
+

--- a/ftw/poodle/locales/fr/LC_MESSAGES/ftw.poodle.po
+++ b/ftw/poodle/locales/fr/LC_MESSAGES/ftw.poodle.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-06 07:54+0000\n"
+"POT-Creation-Date: 2016-10-21 07:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,6 +11,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/poodle/configure.zcml:30
 msgid "A product to make polls to find out when to have a meeting"
 msgstr "A product to make polls to find out when to have a meeting"
 
@@ -18,17 +19,25 @@ msgstr "A product to make polls to find out when to have a meeting"
 msgid "Meeting poll"
 msgstr "Enquête de réunion"
 
+#: ./ftw/poodle/upgrades/configure.zcml:14
+msgid "Remove poodle.js from jsregistry"
+msgstr ""
+
 #: ./ftw/poodle/browser/submit_data.py:30
 msgid "You taked part to the poll"
 msgstr "Votre requête a bien été sauvgardée."
 
+#: ./ftw/poodle/configure.zcml:30
+msgid "ftw.poodle"
+msgstr ""
+
 #. Default: "Date"
-#: ./ftw/poodle/content/poodle.py:31
+#: ./ftw/poodle/content/poodle.py:30
 msgid "ftwpoodle_desc_date"
 msgstr "Format"
 
 #. Default: "Time / Duration"
-#: ./ftw/poodle/content/poodle.py:36
+#: ./ftw/poodle/content/poodle.py:35
 msgid "ftwpoodle_desc_duration"
 msgstr "Heure / durée (HH:MM-HH:MM)"
 
@@ -38,12 +47,12 @@ msgid "ftwpoodle_edit_votes"
 msgstr "Modifier enquête"
 
 #. Default: "Provide a date in a format like MM-DD-AAAA"
-#: ./ftw/poodle/content/poodle.py:33
+#: ./ftw/poodle/content/poodle.py:32
 msgid "ftwpoodle_help_date"
 msgstr "Format: dd-mm-yyyy"
 
 #. Default: "Dates"
-#: ./ftw/poodle/content/poodle.py:40
+#: ./ftw/poodle/content/poodle.py:39
 msgid "ftwpoodle_label_dates"
 msgstr "Date"
 
@@ -58,7 +67,7 @@ msgid "ftwpoodle_mail_subject"
 msgstr "L'utilisateur $ {nom d'utilisateur} a terminé son enquête de réunion"
 
 #. Default: "Results"
-#: ./ftw/poodle/browser/templates/poodletable.pt:50
+#: ./ftw/poodle/browser/templates/poodletable.pt:54
 msgid "ftwpoodle_results"
 msgstr "Résultat"
 
@@ -77,6 +86,11 @@ msgstr "Pas de propositions de date definies"
 msgid "poodle_mailtemplate_body"
 msgstr "L'utilisateur $ {user_name} a participé à l'enquête ${document_url} sur ${portal_title}"
 
+#. Default: "Enable stealth voting"
+#: ./ftw/poodle/content/poodle.py:45
+msgid "stealth_voting"
+msgstr "Vote caché"
+
 #. Default: "Survey is deactivated"
 #: ./ftw/poodle/browser/poodle.py:23
 msgid "survey_deactivated"
@@ -86,3 +100,4 @@ msgstr "Cette enquête est désactivée"
 #: ./ftw/poodle/browser/templates/voted.pt:2
 msgid "text_voted"
 msgstr "Votre requête a bien été sauvgardée. Cliquez sur \"Umfrage bearbeiten\" pour modifier votre requête."
+

--- a/ftw/poodle/locales/fr/LC_MESSAGES/plone.po
+++ b/ftw/poodle/locales/fr/LC_MESSAGES/plone.po
@@ -30,3 +30,4 @@ msgstr "Ouvert"
 #: ../profiles/default/workflows/poodle_workflow/definition.xml
 msgid "Open poodle"
 msgstr "Ouvrir"
+

--- a/ftw/poodle/locales/ftw.poodle.pot
+++ b/ftw/poodle/locales/ftw.poodle.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-06 07:54+0000\n"
+"POT-Creation-Date: 2016-10-21 07:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/poodle/configure.zcml:30
 msgid "A product to make polls to find out when to have a meeting"
 msgstr ""
 
@@ -21,17 +22,25 @@ msgstr ""
 msgid "Meeting poll"
 msgstr ""
 
+#: ./ftw/poodle/upgrades/configure.zcml:14
+msgid "Remove poodle.js from jsregistry"
+msgstr ""
+
 #: ./ftw/poodle/browser/submit_data.py:30
 msgid "You taked part to the poll"
 msgstr ""
 
+#: ./ftw/poodle/configure.zcml:30
+msgid "ftw.poodle"
+msgstr ""
+
 #. Default: "Date"
-#: ./ftw/poodle/content/poodle.py:31
+#: ./ftw/poodle/content/poodle.py:30
 msgid "ftwpoodle_desc_date"
 msgstr ""
 
 #. Default: "Time / Duration"
-#: ./ftw/poodle/content/poodle.py:36
+#: ./ftw/poodle/content/poodle.py:35
 msgid "ftwpoodle_desc_duration"
 msgstr ""
 
@@ -41,12 +50,12 @@ msgid "ftwpoodle_edit_votes"
 msgstr ""
 
 #. Default: "Provide a date in a format like MM-DD-AAAA"
-#: ./ftw/poodle/content/poodle.py:33
+#: ./ftw/poodle/content/poodle.py:32
 msgid "ftwpoodle_help_date"
 msgstr ""
 
 #. Default: "Dates"
-#: ./ftw/poodle/content/poodle.py:40
+#: ./ftw/poodle/content/poodle.py:39
 msgid "ftwpoodle_label_dates"
 msgstr ""
 
@@ -61,7 +70,7 @@ msgid "ftwpoodle_mail_subject"
 msgstr ""
 
 #. Default: "Results"
-#: ./ftw/poodle/browser/templates/poodletable.pt:50
+#: ./ftw/poodle/browser/templates/poodletable.pt:54
 msgid "ftwpoodle_results"
 msgstr ""
 
@@ -80,6 +89,11 @@ msgstr ""
 msgid "poodle_mailtemplate_body"
 msgstr ""
 
+#. Default: "Enable stealth voting"
+#: ./ftw/poodle/content/poodle.py:45
+msgid "stealth_voting"
+msgstr ""
+
 #. Default: "Survey is deactivated"
 #: ./ftw/poodle/browser/poodle.py:23
 msgid "survey_deactivated"
@@ -89,5 +103,4 @@ msgstr ""
 #: ./ftw/poodle/browser/templates/voted.pt:2
 msgid "text_voted"
 msgstr ""
-
 

--- a/ftw/poodle/locales/it/LC_MESSAGES/ftw.poodle.po
+++ b/ftw/poodle/locales/it/LC_MESSAGES/ftw.poodle.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-06 07:54+0000\n"
+"POT-Creation-Date: 2016-10-21 07:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/poodle/configure.zcml:30
 msgid "A product to make polls to find out when to have a meeting"
 msgstr "Un prodotto per eseguire sondaggi sulle possibili date di un incontro"
 
@@ -21,17 +22,25 @@ msgstr "Un prodotto per eseguire sondaggi sulle possibili date di un incontro"
 msgid "Meeting poll"
 msgstr "Sondaggio per incontro"
 
+#: ./ftw/poodle/upgrades/configure.zcml:14
+msgid "Remove poodle.js from jsregistry"
+msgstr ""
+
 #: ./ftw/poodle/browser/submit_data.py:30
 msgid "You taked part to the poll"
 msgstr "Hai preso parte al sondaggio"
 
+#: ./ftw/poodle/configure.zcml:30
+msgid "ftw.poodle"
+msgstr ""
+
 #. Default: "Date"
-#: ./ftw/poodle/content/poodle.py:31
+#: ./ftw/poodle/content/poodle.py:30
 msgid "ftwpoodle_desc_date"
 msgstr "Data"
 
 #. Default: "Time / Duration"
-#: ./ftw/poodle/content/poodle.py:36
+#: ./ftw/poodle/content/poodle.py:35
 msgid "ftwpoodle_desc_duration"
 msgstr "Orario / Durata"
 
@@ -41,12 +50,12 @@ msgid "ftwpoodle_edit_votes"
 msgstr "Modifica preferenze"
 
 #. Default: "Provide a date in a format like MM-DD-AAAA"
-#: ./ftw/poodle/content/poodle.py:33
+#: ./ftw/poodle/content/poodle.py:32
 msgid "ftwpoodle_help_date"
 msgstr "Fornisci una data in un formato quale GG-MM-AAAA"
 
 #. Default: "Dates"
-#: ./ftw/poodle/content/poodle.py:40
+#: ./ftw/poodle/content/poodle.py:39
 msgid "ftwpoodle_label_dates"
 msgstr "Date"
 
@@ -61,7 +70,7 @@ msgid "ftwpoodle_mail_subject"
 msgstr "L'utente ${username} ha conpilato il sondaggio"
 
 #. Default: "Results"
-#: ./ftw/poodle/browser/templates/poodletable.pt:50
+#: ./ftw/poodle/browser/templates/poodletable.pt:54
 msgid "ftwpoodle_results"
 msgstr "Risultati"
 
@@ -80,6 +89,11 @@ msgstr "nessuna data"
 msgid "poodle_mailtemplate_body"
 msgstr "L'utente ${user_name} ha compilato il sondaggio all'indirizzo ${document_url} sul sito ${portal_title} all'indirizzo ${portal_url}"
 
+#. Default: "Enable stealth voting"
+#: ./ftw/poodle/content/poodle.py:45
+msgid "stealth_voting"
+msgstr "Voto a scomparsa"
+
 #. Default: "Survey is deactivated"
 #: ./ftw/poodle/browser/poodle.py:23
 msgid "survey_deactivated"
@@ -89,5 +103,4 @@ msgstr "Sondaggio disattivato"
 #: ./ftw/poodle/browser/templates/voted.pt:2
 msgid "text_voted"
 msgstr "La tua preferenza è stata salvata"
-
 

--- a/ftw/poodle/locales/it/LC_MESSAGES/plone.po
+++ b/ftw/poodle/locales/it/LC_MESSAGES/plone.po
@@ -34,4 +34,3 @@ msgstr "Aperto"
 msgid "Open poodle"
 msgstr "Apri poodle"
 
-

--- a/ftw/poodle/testing.py
+++ b/ftw/poodle/testing.py
@@ -1,6 +1,15 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PLONE_FIXTURE
+from plone.app.testing import PloneSandboxLayer
 from plone.testing import Layer
+from plone.testing import z2
 from plone.testing import zca
 from zope.configuration import xmlconfig
+import ftw.poodle.tests.builders
 
 
 class PoodleVotesZCMLLayer(Layer):
@@ -27,3 +36,30 @@ class PoodleVotesZCMLLayer(Layer):
         del self['configurationContext']
 
 POODLE_VOTES_ZCML_LAYER = PoodleVotesZCMLLayer()
+
+
+class FtwLayer(PloneSandboxLayer):
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+
+    def setUpZope(self, app, configurationContext):
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="Products.DataGridField" />'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '</configure>',
+            context=configurationContext)
+
+        z2.installProduct(app, 'ftw.poodle')
+        z2.installProduct(app, 'DataGridField')
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, 'ftw.poodle:default')
+
+
+FTW_FIXTURE = FtwLayer()
+FTW_FUNCTIONAL = FunctionalTesting(
+    bases=(FTW_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.poodle:functional")

--- a/ftw/poodle/tests/builders.py
+++ b/ftw/poodle/tests/builders.py
@@ -1,0 +1,8 @@
+from ftw.builder import builder_registry
+from ftw.builder.archetypes import ArchetypesBuilder
+
+
+class PoodleBuilder(ArchetypesBuilder):
+    portal_type = 'Poodle'
+
+builder_registry.register('poodle', PoodleBuilder)

--- a/ftw/poodle/tests/test_stealth_voting.py
+++ b/ftw/poodle/tests/test_stealth_voting.py
@@ -1,0 +1,70 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.poodle.testing import FTW_FUNCTIONAL
+from ftw.testbrowser import browsing
+from plone.api import user
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+import transaction
+
+
+# Stealth voting is active for all those tests.
+class TestStealthVoting(TestCase):
+
+    layer = FTW_FUNCTIONAL
+
+    def setUp(self):
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+        login(portal, TEST_USER_NAME)
+
+        self.jane = user.create(email='jane@plone.org',
+                                username='jane',
+                                password='pw4jane')
+        self.jack = user.create(email='jack@plone.org',
+                                username='jack',
+                                password='pw4jack')
+
+        self.folder = create(Builder('folder').titled('Workspaces'))
+
+        dates = [
+            {'date': '01.11.2016', 'duration': '15:00-16:00'},
+            {'date': '15.11.2016', 'duration': '12:00-18:00'},
+            {'date': '20.11.2016', 'duration': '13.00-14.00'}]
+
+        users = [self.jane.getId(), self.jack.getId()]
+
+        self.poodle = create(Builder('poodle').titled('poodle')
+                                              .within(self.folder)
+                                              .having(dates=dates,
+                                                      users=users,
+                                                      stealth_voting=True))
+
+        transaction.commit()
+
+    @browsing
+    def test_user_can_only_see_his_own_voting(self, browser):
+        browser.login('jane', 'pw4jane').visit(self.poodle)
+
+        self.assertEqual(1, len(browser.css('table.poodletable tr.poodle-user')))
+        self.assertEqual(self.jane.getName(),
+                         browser.css('table.poodletable tr.poodle-user td.user').first.text)
+
+    @browsing
+    def test_owner_can_see_every_voting(self, browser):
+        browser.login().visit(self.poodle)
+
+        self.assertEqual(2, len(browser.css('table.poodletable tr.poodle-user')))
+
+    @browsing
+    def test_only_owner_can_see_results(self, browser):
+        browser.login('jane', 'pw4jane').visit(self.poodle)
+
+        self.assertFalse(browser.css('table.poodletable tr.poodle-results'))
+
+        browser.login().visit(self.poodle)
+
+        self.assertEqual(1, len(browser.css('table.poodletable tr.poodle-results')))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ maintainer = 'Mathias Leimgruber'
 
 tests_require = [
     'plone.app.testing',
+    'ftw.builder',
+    'ftw.testbrowser',
     'ftw.testing',
     ]
 
@@ -41,13 +43,14 @@ setup(name='ftw.poodle',
       zip_safe=False,
 
       install_requires=[
-        'setuptools',
-        'Products.DataGridField>=1.9.0',
         'Products.AutocompleteWidget',
-        'plone.principalsource',
-        'ftw.notification.email',
+        'Products.DataGridField>=1.9.0',
         'ftw.notification.base',
+        'ftw.notification.email',
         'ftw.upgrade',
+        'plone.api',
+        'plone.principalsource',
+        'setuptools',
         ],
 
       tests_require=tests_require,


### PR DESCRIPTION
Adds a checkbox to the settings of a poodle which enables the creator to set the stealth voting.
With stealth voting enabled, the participants of the poodle can no longer see any other users nor the result of the poll. All they see is their own column in which they can set their checkboxes.

The owner of the poodle object can still see everything and can always disable the stealth mode.

While the owner of the poodle sees this:
<img width="748" alt="screen shot 2016-10-21 at 10 04 31" src="https://cloud.githubusercontent.com/assets/16755391/19591151/d4dda170-9775-11e6-90b5-36a00a6420db.png">

An invited user will only see this:
<img width="754" alt="screen shot 2016-10-21 at 10 08 19" src="https://cloud.githubusercontent.com/assets/16755391/19591254/53bd4360-9776-11e6-8626-269e937d4c77.png">
